### PR TITLE
Add script for docs preview

### DIFF
--- a/docs/content/docs/preview.md
+++ b/docs/content/docs/preview.md
@@ -1,0 +1,13 @@
+---
+title: Documentation Preview
+---
+
+The `docs:preview` task provides an opiniated solution for previewing the documentation for this project locally.
+
+It sets some expectations on the local project setup:
+
+- [`telescopium`](https://github.com/code0-tech/telescopium) is cloned in the same directory as `pictor`.
+- The directory containing this project is named `pictor`.
+
+All requirements of the `telescopium` project itself apply as well. More information about them are
+available in the [telescopium documentation](../../telescopium/preview.md).

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "storybook:build": "storybook build",
     "storybook:test": "test-storybook",
     "storybook:test:all": "test-storybook --browsers chromium firefox webkit",
-    "storybook:test:update": "npm run storybook:test:all -- -u"
+    "storybook:test:update": "npm run storybook:test:all -- -u",
+    "docs:preview": "npm run --prefix ../telescopium project:preview pictor"
   },
   "author": "Code0",
   "license": "MIT",


### PR DESCRIPTION
Closes #33 

Please note, for this script to work, you need to have `telescopium` cloned next to `pictor`.