### PR TITLE
Rename job for updating snapshots

### DIFF
--- a/.github/workflows/update_snapshots.yml
+++ b/.github/workflows/update_snapshots.yml
@@ -10,7 +10,7 @@ permissions:
   contents: write
 
 jobs:
-  pipeline:
+  update-snapshots:
     if: ${{ github.event.label.name == 'regenerate-snapshots' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The current job name conflicts with the protected branch settings for required checks. This job should not be required and therefore needs another name.