### PR TITLE
Set rangeStrategy to bump for dev dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,12 @@
       "extends": [
         ":assignee(Taucher2003)"
       ]
+    },
+    {
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "rangeStrategy": "bump"
     }
   ]
 }


### PR DESCRIPTION
For dev dependencies, we want to bump the ranges in the package.json. We don't want to do that for runtime dependencies, as that forces downstream dependents to update as well.