### PR TITLE
Disallow vite:dts plugin to fail during build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -11,7 +11,15 @@ export default defineConfig({
     plugins: [
         react(),
         libInjectCss(),
-        dts({ include: ['src'], exclude: ['src/**/*.stories.tsx'] })
+        dts({
+            include: ['src'],
+            exclude: ['src/**/*.stories.tsx'],
+            afterDiagnostic: (diagnostics) => {
+                if (diagnostics.length > 0) {
+                    throw new Error("dts failed");
+                }
+            },
+        })
     ],
     build: {
         lib: {


### PR DESCRIPTION
The `vite:dts` plugin did not fail the build if it encountered errors.